### PR TITLE
Fix: Duplicate key 'around(:example)'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rspec3-snippets",
   "main": "./lib/rspec3-snippets",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Complete RSpec Core, RSpec Expectations and RSpec Mocks snippets.",
   "keywords": [],
   "repository": "https://github.com/fornellas/atom-rspec3-snippets",

--- a/snippets/rspec3.cson
+++ b/snippets/rspec3.cson
@@ -156,7 +156,7 @@
   'after(:example)':
     'prefix': 'afte'
     'body': 'after(:example) do\n  $1\nend'
-  'around(:example)':
+  'around(:example) |example|':
     'prefix': 'aro'
     'body': 'around(:${1:example}) do |${2:example}|\n  $3\nend'
   'around(:suite)':


### PR DESCRIPTION
It seams Atom can't load the snippets due to a duplicate key error.

Atom throws this error when I copy the snippets from the package to my own snippets file:
"Failed to load snippets from '/Users/petertoth/.atom/snippets.cson'"